### PR TITLE
Improved the "PLEASE NOTE" message in Development Workspace Setup.

### DIFF
--- a/docs/NOVA Development/Development Workspace Setup.md
+++ b/docs/NOVA Development/Development Workspace Setup.md
@@ -25,9 +25,9 @@ The NOVA Wrapper for Minecraft can be built in much the same way as NOVA Core, b
 1. Clone [NOVA-Wrapper-MC] and [NOVA-Core] (If you have not cloned NOVA-Core already).
 2. Open your Gradle user home directory (`~/.gradle/` on Linux or OSX, or `C:/Users/[user_name]/.gradle/` on Windows). This will not exist if you have not run Gradle before, if it does not exist, create it.
 3. In your Gradle user home directory create (or edit) the file called `gradle.properties`.
-4. In `gradle.properties` add the line `nova.core.location = /path/to/NovaCore/`. Make sure the path is fully qualified (i.e. starts with `C:\\` or `/`) and points to where you cloned NovaCore.
+4. In `gradle.properties` add the line `nova.core.location = /path/to/NOVA-Core/`. Make sure the path is fully qualified (i.e. starts with `C:\\` or `/`) and points to where you cloned NovaCore.
 
-    **PLEASE NOTE:** You must escape backslashes in paths. Example: `C:\\projects\\NOVA\\NovaWrapper-MC`. 
+    **PLEASE NOTE:** You must escape backslashes in paths. Example: `C:\\projects\\NOVA\\NOVA-Core`. 
 
 5. Go back to where you cloned NOVA-Wrapper-MC and run `gradle setupDecompWorkspace idea genIntellijRuns` if you use IntelliJ IDEA or `gradle setupDecompWorkspace eclipse` if you use Eclipse.
 6. Append `-Dfml.coreMods.load=nova.wrapper.mc1710.NovaMinecraftCore` to the VM arguments of your run configurations.


### PR DESCRIPTION
The "please note" mesage was kinda confusing as it said "NovaWrapper-MC" when it was actually was about the location of the NOVA-Core.
