### PR TITLE
Add installation instructions for Minecraft

### DIFF
--- a/docs/Installation/Minecraft.md
+++ b/docs/Installation/Minecraft.md
@@ -1,0 +1,2 @@
+To install NOVA for Minecraft, download the appropriate wrapper from the front page and the associated Forge version from [files.minecraftforge.net](http://files.minecraftforge.net/).
+After that, follow the installation instructions and drop the NOVA wrapper into `.minecraft/mods/` so that Forge loads it. After that drop all the NOVA mods you want to use into the same folder and NOVA will take care of the rest.

--- a/docs/Installation/index.md
+++ b/docs/Installation/index.md
@@ -1,0 +1,5 @@
+This page contains the installation instructions for every game that is officially supported by NOVA.
+
+## Minecraft
+To install NOVA for Minecraft, download the appropriate wrapper from the front page and the associated Forge version from [files.minecraftforge.net](http://files.minecraftforge.net/).
+After that, follow the installation instructions and drop the NOVA wrapper into `.minecraft/mods/` so that Forge loads it. After that drop all the NOVA mods you want to use into the same folder and NOVA will take care of the rest.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ markdown_extensions:
 
 pages:
   - Home: index.md
+  - Installation: Installation/index.md
+#    - Minecraft: Installation/Minecraft.md
   - Mod Development:
     - Getting started: Mod Development/Getting Started.md
     - NOVA Gradle: Mod Development/NOVA Gradle.md


### PR DESCRIPTION
This PR adds installation instructions for Minecraft (which may not be adequate).
Resolves NOVA-Team/nova-team.github.io#9.

### To do:
- Decide if installation instructions should be in the same page or split into subpages.